### PR TITLE
Preview mode changes the API endpoint

### DIFF
--- a/template.js
+++ b/template.js
@@ -15,6 +15,7 @@ const generateRandom = require('generateRandom');
 
 const containerVersion = getContainerVersion();
 const isDebug = containerVersion.debugMode;
+const isPreview = containerVersion.previewMode;
 const isLoggingEnabled = determinateIsLoggingEnabled();
 const traceId = getRequestHeader('trace-id');
 
@@ -23,7 +24,11 @@ const eventData = getAllEventData();
 sendTrackRequest(mapEvent(eventData, data));
 
 function sendTrackRequest(postBody) {
-    const postUrl = 'https://tr.snapchat.com/v2/conversion';
+    
+    let postUrl = 'https://tr.snapchat.com/v2/conversion';
+    if(isPreview){
+        postUrl = postUrl + '/validate';
+    }
 
     if (isLoggingEnabled) {
         logToConsole(JSON.stringify({


### PR DESCRIPTION
As specified in that [documentation](https://businesshelp.snapchat.com/s/article/capi-event-testing?language=en_US), the endpoint is else when you want to validate the test events. That commit changes the endpoint automatically when the preview mode is activated.