### PR TITLE
_scid cookie optional creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ Snapchat conversion API tag for Google Tag Manager server container allows sendi
 
 Snapchat CAPI tag automatically normalized and hashed with lowercase hex SHA256 format. All user parameters (plain text email, mobile identifier, IP address, and phone number).
 
-Tag supports event deduplication.
+The tag supports event deduplication.
 
 ### Getting started
+
 According to Snap Marketing API, it is required to use Access Token to send events to Snap server.
 
 ### To use this tag, you'll need:
@@ -26,4 +27,4 @@ According to Snap Marketing API, it is required to use Access Token to send even
 
 ## Open Source
 
-Snapchat Tag for GTM Server Side is developing and maintained by [Stape Team](https://stape.io/) under the Apache 2.0 license.
+Snapchat Tag for GTM Server Side is developed and maintained by [Stape Team](https://stape.io/) under the Apache 2.0 license.

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,6 @@
 homepage: "https://stape.io/"
 versions:
-  - sha: 74c360803e598eab8146b3aed6d2ef5030fa9b16
+  - sha: b554283af7cc43d31e53bf88d9f596613b31ebc5
     changeNotes: Set Browser ID cookie optionally based on user preference.
   - sha: 46d3affa54edf6955b14df166237884cfeda7552
     changeNotes: Set click id cookie optionally.

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,6 @@
 homepage: "https://stape.io/"
 versions:
-  - sha: b554283af7cc43d31e53bf88d9f596613b31ebc5
+  - sha: 870121ce1fd0b798d00d917ec3313834c30d5f85
     changeNotes: Set Browser ID cookie optionally based on user preference.
   - sha: 46d3affa54edf6955b14df166237884cfeda7552
     changeNotes: Set click id cookie optionally.

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,5 +1,7 @@
 homepage: "https://stape.io/"
 versions:
+  - sha: a2d8ecc7957ee7d01012ab7543569b5c7218e730
+    changeNotes: Set Browser ID cookie optionally.
   - sha: 46d3affa54edf6955b14df166237884cfeda7552
     changeNotes: Set click id cookie optionally.
   - sha: 1bb3648e86c1e6586c0169097f1d49b6725203be

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,7 +1,7 @@
 homepage: "https://stape.io/"
 versions:
-  - sha: a2d8ecc7957ee7d01012ab7543569b5c7218e730
-    changeNotes: Set Browser ID cookie optionally.
+  - sha: 74c360803e598eab8146b3aed6d2ef5030fa9b16
+    changeNotes: Set Browser ID cookie optionally based on user preference.
   - sha: 46d3affa54edf6955b14df166237884cfeda7552
     changeNotes: Set click id cookie optionally.
   - sha: 1bb3648e86c1e6586c0169097f1d49b6725203be

--- a/template.js
+++ b/template.js
@@ -24,7 +24,6 @@ const traceId = getRequestHeader('trace-id');
 const eventData = getAllEventData();
 const url = eventData.page_location || getRequestHeader('referer');
 
-
 if (!isConsentGivenOrNotRequired()) {
   return data.gtmOnSuccess();
 }

--- a/template.js
+++ b/template.js
@@ -24,6 +24,7 @@ const traceId = getRequestHeader('trace-id');
 const eventData = getAllEventData();
 const url = eventData.page_location || getRequestHeader('referer');
 
+
 if (!isConsentGivenOrNotRequired()) {
   return data.gtmOnSuccess();
 }
@@ -436,22 +437,6 @@ function addUserData(eventData, mappedData) {
   return mappedData;
 }
 
-function determinateIsLoggingEnabled() {
-  if (!data.logType) {
-    return isDebug;
-  }
-
-  if (data.logType === 'no') {
-    return false;
-  }
-
-  if (data.logType === 'debug') {
-    return isDebug;
-  }
-
-  return data.logType === 'always';
-}
-
 function createUUID() {
   let len = 36;
   let chars = '0123456789abcdef'.split('');
@@ -470,21 +455,12 @@ function createUUID() {
 }
 
 function getSCID() {
-  const scidCookie = getCookieValues('_scid')[0] || commonCookie._scid;
-
-  if (scidCookie) {
-    return scidCookie;
+  const scid = getCookieValues('_scid')[0] || commonCookie._scid || eventData._scid || eventData.scid;
+  if (scid) {
+    return scid;
   }
 
-  if (eventData._scid) {
-    return eventData._scid;
-  }
-
-  if (eventData.scid) {
-    return eventData.scid;
-  }
-
-  if (data.eventConversionType === 'WEB') {
+  if (data.eventConversionType === 'WEB' && !data.notSetBrowserIdCookie) {
     return createUUID();
   }
 
@@ -510,4 +486,20 @@ function isConsentGivenOrNotRequired() {
 function isValidValue(value) {
   const valueType = getType(value);
   return valueType !== 'null' && valueType !== 'undefined' && value !== '';
+}
+
+function determinateIsLoggingEnabled() {
+  if (!data.logType) {
+    return isDebug;
+  }
+
+  if (data.logType === 'no') {
+    return false;
+  }
+
+  if (data.logType === 'debug') {
+    return isDebug;
+  }
+
+  return data.logType === 'always';
 }

--- a/template.js
+++ b/template.js
@@ -70,11 +70,11 @@ function sendTrackRequest(mappedEvent) {
     httpOnly: !!data.useHttpOnlyCookie
   };
 
-  if (mappedEvent.user_data.sc_click_id && !data.notSetClickID) {
+  if (mappedEvent.user_data.sc_click_id && !data.notSetClickIdCookie) {
     setCookie('_scclid', mappedEvent.user_data.sc_click_id, cookieOptions);
   }
 
-  if (mappedEvent.user_data.sc_cookie1) {
+  if (mappedEvent.user_data.sc_cookie1 && !data.notSetBrowserIdCookie) {
     setCookie('_scid', mappedEvent.user_data.sc_cookie1, cookieOptions);
   }
 

--- a/template.tpl
+++ b/template.tpl
@@ -326,7 +326,7 @@ ___TEMPLATE_PARAMETERS___
     "name": "notSetBrowserIdCookie",
     "checkboxText": "Do not set Browser ID (_scid) cookie",
     "simpleValueType": true,
-    "help": "Do not set Browser ID (_scid) cookie if it was added to user data.",
+    "help": "Do not set Browser ID (_scid) cookie if it was added to user data.\n\u003cbr\u003e\nDo not auto-generate it.\n\u003cbr\u003e\nIf an existing Browser ID is found, it will still be sent in the request but not stored as a cookie. It can be sourced from:\u003cul\u003e\n\u003cli\u003ean already existing \u003ci\u003e_scid\u003c/i\u003e cookie\u003c/li\u003e\n\u003cli\u003eEvent Data parameters: \u003ci\u003ecommonCookie._scid\u003c/i\u003e, \u003ci\u003escid\u003c/i\u003e or \u003ci\u003e_scid\u003c/i\u003e\u003c/li\u003e\n\u003c/ul\u003e",
     "defaultValue": false
   },
   {
@@ -494,6 +494,10 @@ ___TEMPLATE_PARAMETERS___
               {
                 "value": "sc_click_id",
                 "displayValue": "Click ID"
+              },
+              {
+                "value": "sc_cookie1",
+                "displayValue": "Browser ID"
               }
             ]
           },
@@ -679,6 +683,7 @@ const traceId = getRequestHeader('trace-id');
 
 const eventData = getAllEventData();
 const url = eventData.page_location || getRequestHeader('referer');
+
 
 if (!isConsentGivenOrNotRequired()) {
   return data.gtmOnSuccess();
@@ -1092,22 +1097,6 @@ function addUserData(eventData, mappedData) {
   return mappedData;
 }
 
-function determinateIsLoggingEnabled() {
-  if (!data.logType) {
-    return isDebug;
-  }
-
-  if (data.logType === 'no') {
-    return false;
-  }
-
-  if (data.logType === 'debug') {
-    return isDebug;
-  }
-
-  return data.logType === 'always';
-}
-
 function createUUID() {
   let len = 36;
   let chars = '0123456789abcdef'.split('');
@@ -1126,21 +1115,12 @@ function createUUID() {
 }
 
 function getSCID() {
-  const scidCookie = getCookieValues('_scid')[0] || commonCookie._scid;
-
-  if (scidCookie) {
-    return scidCookie;
+  const scid = getCookieValues('_scid')[0] || commonCookie._scid || eventData._scid || eventData.scid;
+  if (scid) {
+    return scid;
   }
 
-  if (eventData._scid) {
-    return eventData._scid;
-  }
-
-  if (eventData.scid) {
-    return eventData.scid;
-  }
-
-  if (data.eventConversionType === 'WEB') {
+  if (data.eventConversionType === 'WEB' && !data.notSetBrowserIdCookie) {
     return createUUID();
   }
 
@@ -1166,6 +1146,22 @@ function isConsentGivenOrNotRequired() {
 function isValidValue(value) {
   const valueType = getType(value);
   return valueType !== 'null' && valueType !== 'undefined' && value !== '';
+}
+
+function determinateIsLoggingEnabled() {
+  if (!data.logType) {
+    return isDebug;
+  }
+
+  if (data.logType === 'no') {
+    return false;
+  }
+
+  if (data.logType === 'debug') {
+    return isDebug;
+  }
+
+  return data.logType === 'always';
 }
 
 
@@ -1516,6 +1512,28 @@ scenarios:
     });
 
     runCode(mockData);
+- name: Browser ID parameter is NOT auto-generated and CAN be set on the request if
+    checkbox is enabled
+  code: |-
+    const JSON = require('JSON');
+
+    mockData.notSetBrowserIdCookie = true;
+
+    const scidValue = 'scid';
+    mock('getAllEventData', {
+      event_name: 'purchase',
+      eventConversionType: 'WEB',
+      _scid: scidValue,
+      //click_id: 'clickid'
+    });
+
+
+    mock('sendHttpRequest', (url, callback, headers, body) => {
+      const bodyParsed = JSON.parse(body);
+      assertThat(bodyParsed.data[0].user_data.sc_cookie1).isEqualTo(scidValue);
+    });
+
+    runCode(mockData);
 - name: Browser ID cookie must be set if checkbox is disabled
   code: |-
     const setCookie = require('setCookie');
@@ -1525,6 +1543,7 @@ scenarios:
       event_name: 'purchase',
       eventConversionType: 'WEB',
       _scid: scidValue,
+      //click_id: 'clickid'
     });
 
 
@@ -1535,8 +1554,6 @@ scenarios:
 
     runCode(mockData);
 setup: |-
-  const logToConsole = require('logToConsole');
-
   const mockData = {
     pixelId: '123123123',
     accessToken: 'accessToken123'

--- a/template.tpl
+++ b/template.tpl
@@ -684,7 +684,6 @@ const traceId = getRequestHeader('trace-id');
 const eventData = getAllEventData();
 const url = eventData.page_location || getRequestHeader('referer');
 
-
 if (!isConsentGivenOrNotRequired()) {
   return data.gtmOnSuccess();
 }

--- a/template.tpl
+++ b/template.tpl
@@ -1493,8 +1493,6 @@ ___TESTS___
 scenarios:
 - name: Browser ID cookie must NOT be set if checkbox is enabled
   code: |-
-    const setCookie = require('setCookie');
-
     mockData.notSetBrowserIdCookie = true;
 
     const scidValue = 'scid';
@@ -1511,11 +1509,9 @@ scenarios:
     });
 
     runCode(mockData);
-- name: Browser ID parameter is NOT auto-generated and CAN be set on the request if
-    checkbox is enabled
+- name: Browser ID parameter is NOT auto-generated and IS set on the request if it
+    comes from other source and if checkbox is enabled
   code: |-
-    const JSON = require('JSON');
-
     mockData.notSetBrowserIdCookie = true;
 
     const scidValue = 'scid';
@@ -1533,10 +1529,24 @@ scenarios:
     });
 
     runCode(mockData);
+- name: Browser ID parameter is NOT auto-generated and is NOT set on the request if
+    it no other sources contains its value and if checkbox is enabled
+  code: |-
+    mockData.notSetBrowserIdCookie = true;
+
+    mock('getAllEventData', {
+      event_name: 'purchase',
+      eventConversionType: 'WEB'
+    });
+
+    mock('sendHttpRequest', (url, callback, headers, body) => {
+      const bodyParsed = JSON.parse(body);
+      assertThat(bodyParsed.data[0].user_data.sc_cookie1).isUndefined();
+    });
+
+    runCode(mockData);
 - name: Browser ID cookie must be set if checkbox is disabled
   code: |-
-    const setCookie = require('setCookie');
-
     const scidValue = 'scid';
     mock('getAllEventData', {
       event_name: 'purchase',
@@ -1553,6 +1563,9 @@ scenarios:
 
     runCode(mockData);
 setup: |-
+  const setCookie = require('setCookie');
+  const JSON = require('JSON');
+
   const mockData = {
     pixelId: '123123123',
     accessToken: 'accessToken123'


### PR DESCRIPTION
Hi.

Added a checkbox _Do not set Browser ID (\_scid) cookie_ so that the user can control the behavior of the Browser ID cookie as well (There is already a similar checkbox to manage the creation of the Click ID cookie).

If the Browser ID checkbox is marked (_Do not set Browser ID (\_scid) cookie_):
- Browser ID must not be put in cookie.
- Browser ID must not be randomly generated.
- Browser ID can be sent in the request but not put in cookie if its value comes from an already-existing `_scid` cookie, Data Tag common `_scid` cookie, or `eventData.scid` or `eventData._scid` parameters.

I added the `sc_cookie1` (Browser ID) as an option to the User Data drop-down menu because it was missing for some reason. 