### PR TITLE
Add support for Big Query logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The tag supports event deduplication.
 
 ### Getting started
 
-According to Snap Marketing API, it is required to use Access Token to send events to Snap server.
+According to Snap Marketing API, it is required to use Access Token to send events to Snapchat server.
 
 ### To use this tag, you'll need:
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,5 +1,7 @@
 homepage: "https://stape.io/"
 versions:
+  - sha: 054877764aeddf11387157b0f4f159d40d6d8c00
+    changeNotes: Add support for BigQuery logging.
   - sha: 870121ce1fd0b798d00d917ec3313834c30d5f85
     changeNotes: Set Browser ID cookie optionally based on user preference.
   - sha: 46d3affa54edf6955b14df166237884cfeda7552

--- a/template.tpl
+++ b/template.tpl
@@ -652,6 +652,73 @@ ___TEMPLATE_PARAMETERS___
         "defaultValue": "debug"
       }
     ]
+  },
+  {
+    "displayName": "BigQuery Logs Settings",
+    "name": "bigQueryLogsGroup",
+    "groupStyle": "ZIPPY_CLOSED",
+    "type": "GROUP",
+    "subParams": [
+      {
+        "type": "RADIO",
+        "name": "bigQueryLogType",
+        "radioItems": [
+          {
+            "value": "no",
+            "displayValue": "Do not log to BigQuery"
+          },
+          {
+            "value": "always",
+            "displayValue": "Log to BigQuery"
+          }
+        ],
+        "simpleValueType": true,
+        "defaultValue": "no"
+      },
+      {
+        "type": "GROUP",
+        "name": "logsBigQueryConfigGroup",
+        "groupStyle": "NO_ZIPPY",
+        "subParams": [
+          {
+            "type": "TEXT",
+            "name": "logBigQueryProjectId",
+            "displayName": "BigQuery Project ID",
+            "simpleValueType": true,
+            "help": "Optional.  \u003cbr\u003e\u003cbr\u003e  If omitted, it will be retrieved from the environment variable \u003cI\u003eGOOGLE_CLOUD_PROJECT\u003c/i\u003e where the server container is running. If the server container is running on Google Cloud, \u003cI\u003eGOOGLE_CLOUD_PROJECT\u003c/i\u003e will already be set to the Google Cloud project\u0027s ID."
+          },
+          {
+            "type": "TEXT",
+            "name": "logBigQueryDatasetId",
+            "displayName": "BigQuery Dataset ID",
+            "simpleValueType": true,
+            "valueValidators": [
+              {
+                "type": "NON_EMPTY"
+              }
+            ]
+          },
+          {
+            "type": "TEXT",
+            "name": "logBigQueryTableId",
+            "displayName": "BigQuery Table ID",
+            "simpleValueType": true,
+            "valueValidators": [
+              {
+                "type": "NON_EMPTY"
+              }
+            ]
+          }
+        ],
+        "enablingConditions": [
+          {
+            "paramName": "bigQueryLogType",
+            "paramValue": "always",
+            "type": "EQUALS"
+          }
+        ]
+      }
+    ]
   }
 ]
 
@@ -675,19 +742,19 @@ const generateRandom = require('generateRandom');
 const parseUrl = require('parseUrl');
 const makeNumber = require('makeNumber');
 const encodeUriComponent = require('encodeUriComponent');
+const BigQuery = require('BigQuery');
 
-const containerVersion = getContainerVersion();
-const isDebug = containerVersion.debugMode;
-const isLoggingEnabled = determinateIsLoggingEnabled();
+/**********************************************************************************************/
+
 const traceId = getRequestHeader('trace-id');
 
 const eventData = getAllEventData();
-const url = eventData.page_location || getRequestHeader('referer');
 
 if (!isConsentGivenOrNotRequired()) {
   return data.gtmOnSuccess();
 }
 
+const url = eventData.page_location || getRequestHeader('referer');
 if (url && url.lastIndexOf('https://gtm-msr.appspot.com/', 0) === 0) {
   return data.gtmOnSuccess();
 }
@@ -701,25 +768,28 @@ const commonCookie = eventData.common_cookie || {};
 
 sendTrackRequest(mapEvent(eventData, data));
 
+if (data.useOptimisticScenario) {
+  data.gtmOnSuccess();
+}
+
+/**********************************************************************************************/
+// Vendor related functions
+
 function sendTrackRequest(mappedEvent) {
   const postBody = {
     data: [mappedEvent]
   };
   const postUrl = getPostUrl();
 
-  if (isLoggingEnabled) {
-    logToConsole(
-      JSON.stringify({
-        Name: 'Snapchat',
-        Type: 'Request',
-        TraceId: traceId,
-        EventName: mappedEvent.event_name,
-        RequestMethod: 'POST',
-        RequestUrl: postUrl,
-        RequestBody: postBody
-      })
-    );
-  }
+  log({
+    Name: 'Snapchat',
+    Type: 'Request',
+    TraceId: traceId,
+    EventName: mappedEvent.event_name,
+    RequestMethod: 'POST',
+    RequestUrl: postUrl,
+    RequestBody: postBody
+  });
 
   const cookieOptions = {
     domain: 'auto',
@@ -741,19 +811,16 @@ function sendTrackRequest(mappedEvent) {
   sendHttpRequest(
     postUrl,
     (statusCode, headers, body) => {
-      if (isLoggingEnabled) {
-        logToConsole(
-          JSON.stringify({
-            Name: 'Snapchat',
-            Type: 'Response',
-            TraceId: traceId,
-            EventName: mappedEvent.event_name,
-            ResponseStatusCode: statusCode,
-            ResponseHeaders: headers,
-            ResponseBody: body
-          })
-        );
-      }
+      log({
+        Name: 'Snapchat',
+        Type: 'Response',
+        TraceId: traceId,
+        EventName: mappedEvent.event_name,
+        ResponseStatusCode: statusCode,
+        ResponseHeaders: headers,
+        ResponseBody: body
+      });
+
       if (!data.useOptimisticScenario) {
         if (statusCode >= 200 && statusCode < 400) {
           data.gtmOnSuccess();
@@ -772,10 +839,6 @@ function sendTrackRequest(mappedEvent) {
   );
 }
 
-if (data.useOptimisticScenario) {
-  data.gtmOnSuccess();
-}
-
 function getPostUrl() {
   let postUrl = 'https://tr.snapchat.com/v3/' + encodeUriComponent(pixelOrAppId) + '/events';
   if (data.validate) {
@@ -787,9 +850,9 @@ function getPostUrl() {
 
 function getEventName(eventData, data) {
   if (data.eventType === 'inherit') {
-    let eventName = eventData.event_name;
+    const eventName = eventData.event_name;
 
-    let gaToEventName = {
+    const gaToEventName = {
       page_view: 'PAGE_VIEW',
       'gtm.dom': 'PAGE_VIEW',
       add_to_cart: 'ADD_CART',
@@ -870,7 +933,7 @@ function addCustomData(eventData, mappedData) {
 
     const itemIdKey = data.itemIdKey ? data.itemIdKey : 'item_id';
     eventData.items.forEach((d, i) => {
-      let content = {};
+      const content = {};
       if (d[itemIdKey]) content.id = d[itemIdKey];
       if (d.quantity) content.quantity = d.quantity;
       if (d.delivery_category) content.delivery_category = d.delivery_category;
@@ -963,14 +1026,6 @@ function addServerData(eventData, mappedData) {
   }
 
   return mappedData;
-}
-
-function isHashed(value) {
-  if (!value) {
-    return false;
-  }
-
-  return makeString(value).match('^[A-Fa-f0-9]{64}$') !== null;
 }
 
 function hashData(value) {
@@ -1097,8 +1152,8 @@ function addUserData(eventData, mappedData) {
 }
 
 function createUUID() {
-  let len = 36;
-  let chars = '0123456789abcdef'.split('');
+  const len = 36;
+  const chars = '0123456789abcdef'.split('');
   let uuid = '';
 
   for (var i = 0; i < len; i++) {
@@ -1135,6 +1190,14 @@ function getClickId() {
   return getCookieValues('_scclid')[0] || commonCookie._scclid;
 }
 
+/**********************************************************************************************/
+// Helpers
+
+function isHashed(value) {
+  if (!value) return false;
+  return makeString(value).match('^[A-Fa-f0-9]{64}$') !== null;
+}
+
 function isConsentGivenOrNotRequired() {
   if (data.adStorageConsent !== 'required') return true;
   if (eventData.consent_state) return !!eventData.consent_state.ad_storage;
@@ -1147,7 +1210,77 @@ function isValidValue(value) {
   return valueType !== 'null' && valueType !== 'undefined' && value !== '';
 }
 
+function log(rawDataToLog) {
+  const logDestinationsHandlers = {};
+  if (determinateIsLoggingEnabled()) logDestinationsHandlers.console = logConsole;
+  if (determinateIsLoggingEnabledForBigQuery()) logDestinationsHandlers.bigQuery = logToBigQuery;
+
+  // Key mappings for each log destination
+  const keyMappings = {
+    // No transformation for Console is needed.
+    bigQuery: {
+      Name: 'tag_name',
+      Type: 'type',
+      TraceId: 'trace_id',
+      EventName: 'event_name',
+      RequestMethod: 'request_method',
+      RequestUrl: 'request_url',
+      RequestBody: 'request_body',
+      ResponseStatusCode: 'response_status_code',
+      ResponseHeaders: 'response_headers',
+      ResponseBody: 'response_body'
+    }
+  };
+
+  for (const logDestination in logDestinationsHandlers) {
+    const handler = logDestinationsHandlers[logDestination];
+    if (!handler) continue;
+
+    const mapping = keyMappings[logDestination];
+    const dataToLog = mapping ? {} : rawDataToLog;
+    // Map keys based on the log destination
+    if (mapping) {
+      for (const key in rawDataToLog) {
+        const mappedKey = mapping[key] || key; // Fallback to original key if no mapping exists
+        dataToLog[mappedKey] = rawDataToLog[key];
+      }
+    }
+
+    handler(dataToLog);
+  }
+}
+
+function logConsole(dataToLog) {
+  logToConsole(JSON.stringify(dataToLog));
+}
+
+function logToBigQuery(dataToLog) {
+  const connectionInfo = {
+    projectId: data.logBigQueryProjectId,
+    datasetId: data.logBigQueryDatasetId,
+    tableId: data.logBigQueryTableId
+  };
+
+  // timestamp is required.
+  dataToLog.timestamp = getTimestampMillis();
+
+  // Columns with type JSON need to be stringified.
+  ['request_body', 'response_headers', 'response_body'].forEach((p) => {
+    const value = dataToLog[p];
+    // These types don't need to be stringified.
+    if (['string', 'null', 'undefined'].indexOf(getType(value)) === -1) dataToLog[p] = JSON.stringify(value);
+  });
+
+  // assertApi doesn't work for 'BigQuery.insert()'. It's needed to convert BigQuery into a function when testing.
+  // Ref: https://gtm-gear.com/posts/gtm-templates-testing/
+  const bigquery = getType(BigQuery) === 'function' ? BigQuery() /* Only during Unit Tests */ : BigQuery;
+  bigquery.insert(connectionInfo, [dataToLog], { ignoreUnknownValues: true });
+}
+
 function determinateIsLoggingEnabled() {
+  const containerVersion = getContainerVersion();
+  const isDebug = !!(containerVersion && (containerVersion.debugMode || containerVersion.previewMode));
+
   if (!data.logType) {
     return isDebug;
   }
@@ -1161,6 +1294,11 @@ function determinateIsLoggingEnabled() {
   }
 
   return data.logType === 'always';
+}
+
+function determinateIsLoggingEnabledForBigQuery() {
+  if (data.bigQueryLogType === 'no') return false;
+  return data.bigQueryLogType === 'always';
 }
 
 
@@ -1484,6 +1622,67 @@ ___SERVER_PERMISSIONS___
       "isEditedByUser": true
     },
     "isRequired": true
+  },
+  {
+    "instance": {
+      "key": {
+        "publicId": "access_bigquery",
+        "versionId": "1"
+      },
+      "param": [
+        {
+          "key": "allowedTables",
+          "value": {
+            "type": 2,
+            "listItem": [
+              {
+                "type": 3,
+                "mapKey": [
+                  {
+                    "type": 1,
+                    "string": "projectId"
+                  },
+                  {
+                    "type": 1,
+                    "string": "datasetId"
+                  },
+                  {
+                    "type": 1,
+                    "string": "tableId"
+                  },
+                  {
+                    "type": 1,
+                    "string": "operation"
+                  }
+                ],
+                "mapValue": [
+                  {
+                    "type": 1,
+                    "string": "*"
+                  },
+                  {
+                    "type": 1,
+                    "string": "*"
+                  },
+                  {
+                    "type": 1,
+                    "string": "*"
+                  },
+                  {
+                    "type": 1,
+                    "string": "write"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "clientAnnotations": {
+      "isEditedByUser": true
+    },
+    "isRequired": true
   }
 ]
 
@@ -1503,7 +1702,6 @@ scenarios:
       //click_id: 'clickid'
     });
 
-
     mock('setCookie', (name, value, options, encode) => {
       if (name === '_scid' && value === scidValue) fail('_scid cookie must not be set when the checkbox is enabled.');
     });
@@ -1521,7 +1719,6 @@ scenarios:
       _scid: scidValue,
       //click_id: 'clickid'
     });
-
 
     mock('sendHttpRequest', (url, callback, headers, body) => {
       const bodyParsed = JSON.parse(body);
@@ -1555,25 +1752,88 @@ scenarios:
       //click_id: 'clickid'
     });
 
-
     mock('setCookie', (name, value, options, encode) => {
       assertThat(name).isEqualTo('_scid');
       assertThat(value).isEqualTo(scidValue);
     });
 
     runCode(mockData);
+- name: Should log to console, if the 'Always log to console' option is selected
+  code: "mockData.logType = 'always';\n\nconst expectedDebugMode = true;\nmock('getContainerVersion',\
+    \ () => {\n  return {\n    debugMode: expectedDebugMode\n  };\n}); \n\nmock('logToConsole',\
+    \ (logData) => {\n  const parsedLogData = JSON.parse(logData);\n  requiredConsoleKeys.forEach(p\
+    \ => assertThat(parsedLogData[p]).isDefined());\n});\n\nrunCode(mockData);\n\n\
+    assertApi('logToConsole').wasCalled();\n"
+- name: Should log to console, if the 'Log during debug and preview' option is selected
+    AND is on preview mode
+  code: |
+    mockData.logType = 'debug';
+
+    const expectedDebugMode = true;
+    mock('getContainerVersion', () => {
+      return {
+        debugMode: expectedDebugMode
+      };
+    });
+
+    mock('logToConsole', (logData) => {
+      const parsedLogData = JSON.parse(logData);
+      requiredConsoleKeys.forEach(p => assertThat(parsedLogData[p]).isDefined());
+    });
+
+    runCode(mockData);
+
+    assertApi('logToConsole').wasCalled();
+- name: Should NOT log to console, if the 'Log during debug and preview' option is
+    selected AND is NOT on preview mode
+  code: "mockData.logType = 'debug';\n\nconst expectedDebugMode = false;\nmock('getContainerVersion',\
+    \ () => {\n  return {\n    debugMode: expectedDebugMode\n  };\n}); \n\nrunCode(mockData);\n\
+    \nassertApi('logToConsole').wasNotCalled();\n"
+- name: Should NOT log to console, if the 'Do not log' option is selected
+  code: |
+    mockData.logType = 'no';
+
+    runCode(mockData);
+
+    assertApi('logToConsole').wasNotCalled();
+- name: Should log to BQ, if the 'Log to BigQuery' option is selected
+  code: "mockData.bigQueryLogType = 'always';\n\n// assertApi doesn't work for 'BigQuery.insert()'.\n\
+    // Ref: https://gtm-gear.com/posts/gtm-templates-testing/\nmock('BigQuery', ()\
+    \ => {\n  return { \n    insert: (connectionInfo, rows, options) => { \n     \
+    \ assertThat(connectionInfo).isDefined();\n      assertThat(rows).isArray();\n\
+    \      assertThat(rows).hasLength(1);\n      requiredBqKeys.forEach(p => assertThat(rows[0][p]).isDefined());\n\
+    \      assertThat(options).isEqualTo(expectedBqOptions);\n      return Promise.create((resolve,\
+    \ reject) => {\n        resolve();\n      });\n    }\n  };\n});\n\nrunCode(mockData);"
+- name: Should NOT log to BQ, if the 'Do not log to BigQuery' option is selected
+  code: "mockData.bigQueryLogType = 'no';\n\n// assertApi doesn't work for 'BigQuery.insert()'.\n\
+    // Ref: https://gtm-gear.com/posts/gtm-templates-testing/\nmock('BigQuery', ()\
+    \ => {\n  return { \n    insert: (connectionInfo, rows, options) => { \n     \
+    \ fail('BigQuery.insert should not have been called.');\n      return Promise.create((resolve,\
+    \ reject) => {\n        resolve();\n      });\n    }\n  };\n});\n\nrunCode(mockData);"
 setup: |-
   const setCookie = require('setCookie');
   const JSON = require('JSON');
+  const Promise = require('Promise');
+
+  const requiredConsoleKeys = ['Type', 'TraceId', 'Name'];
+  const requiredBqKeys = ['timestamp', 'type', 'trace_id', 'tag_name'];
+
+  const expectedValue = 'test';
+  const expectedBqOptions = { ignoreUnknownValues: true };
+  const expectedPixelId = '1111111111111';
 
   const mockData = {
-    pixelId: '123123123',
-    accessToken: 'accessToken123'
+    pixelId: expectedPixelId,
+    accessToken: expectedValue,
+    eventType: 'custom',
+    eventName: expectedValue,
+    logBigQueryProjectId: expectedValue,
+    logBigQueryDatasetId: expectedValue,
+    logBigQueryTableId: expectedValue,
   };
 
 
 ___NOTES___
 
 Created on 03/03/2022, 19:13:03
-
 


### PR DESCRIPTION
Hi.

- Added support for BigQuery logging for the [GTMS-7](https://github.com/stape-io/gtm-standards/blob/main/standards/GTMS-7.md).
  - Now, the tag has only one entry point for logging, the `log` function. It receives the data in the format used by the `logToConsole` logs, and decides where to route the data to (only Console, only BigQuery, or both), based on the options the end-user chose in the template UI. It also transforms the data into the required BQ format.
- Added tests for both types of logs (Console and BigQuery).
- Updated the README.