### PR TITLE
Big Query log improvement

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,5 +1,7 @@
 homepage: "https://stape.io/"
 versions:
+  - sha: 523dfb8ed42bf40dac753d8787ee9d4a785d59c9
+    changeNotes: Improve JSON handling for BQ logging.
   - sha: 054877764aeddf11387157b0f4f159d40d6d8c00
     changeNotes: Add support for BigQuery logging.
   - sha: 870121ce1fd0b798d00d917ec3313834c30d5f85

--- a/template.js
+++ b/template.js
@@ -539,9 +539,17 @@ function logToBigQuery(dataToLog) {
 
   // Columns with type JSON need to be stringified.
   ['request_body', 'response_headers', 'response_body'].forEach((p) => {
-    const value = dataToLog[p];
-    // These types don't need to be stringified.
-    if (['string', 'null', 'undefined'].indexOf(getType(value)) === -1) dataToLog[p] = JSON.stringify(value);
+    // The JSON.parse of GTM Sandboxed JS should not throw and should return undefined if parsing
+    // a malformed JSON. This would be great to parse stringified objects and arrays, so that it's not needed
+    // to convert them back into their original format in BigQuery.
+    // Although it does return undefined and permits the code to continue running,
+    // it throws an error after the execution is complete, making tests and the overall execution to show as failed.
+    // Ref: https://developers.google.com/tag-platform/tag-manager/server-side/api#json
+
+    // If someday this is fixed, the lines below can be changed to this one:
+    // dataToLog[p] = JSON.stringify(JSON.parse(dataToLog[p]) || dataToLog[p]);
+
+    dataToLog[p] = JSON.stringify(dataToLog[p]);
   });
 
   // assertApi doesn't work for 'BigQuery.insert()'. It's needed to convert BigQuery into a function when testing.

--- a/template.tpl
+++ b/template.tpl
@@ -1266,9 +1266,17 @@ function logToBigQuery(dataToLog) {
 
   // Columns with type JSON need to be stringified.
   ['request_body', 'response_headers', 'response_body'].forEach((p) => {
-    const value = dataToLog[p];
-    // These types don't need to be stringified.
-    if (['string', 'null', 'undefined'].indexOf(getType(value)) === -1) dataToLog[p] = JSON.stringify(value);
+    // The JSON.parse of GTM Sandboxed JS should not throw and should return undefined if parsing
+    // a malformed JSON. This would be great to parse stringified objects and arrays, so that it's not needed
+    // to convert them back into their original format in BigQuery.
+    // Although it does return undefined and permits the code to continue running,
+    // it throws an error after the execution is complete, making tests and the overall execution to show as failed.
+    // Ref: https://developers.google.com/tag-platform/tag-manager/server-side/api#json
+
+    // If someday this is fixed, the lines below can be changed to this one:
+    // dataToLog[p] = JSON.stringify(JSON.parse(dataToLog[p]) || dataToLog[p]);
+
+    dataToLog[p] = JSON.stringify(dataToLog[p]);
   });
 
   // assertApi doesn't work for 'BigQuery.insert()'. It's needed to convert BigQuery into a function when testing.


### PR DESCRIPTION
Hi.

When testing I noticed that some APIs don't return a valid string or value to be inserted on the BQ table.
Thus, it's required that they be passed into the `JSON.stringify` first.